### PR TITLE
change maxAge to 2d / offfline nodes blink to 2h

### DIFF
--- a/meshviewer/config.json
+++ b/meshviewer/config.json
@@ -5,8 +5,8 @@
   "siteName": "Freifunk Hamburg",
   "mapSigmaScale": 0.54,
   "showContact": false,
-  "maxAge": 30,
-  "blinkingHours": 0,
+  "maxAge": 2,
+  "blinkingHours": 2,
   "mapLayers": [
     { "name": "MapQuest (OSM)",
       "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",


### PR DESCRIPTION
This will show only nodes that are offline since 2 days or new since 2 days in "Aktuelles"

and add blinking nodes for the first two hours offline time
